### PR TITLE
Show a redirective link to Konachan.net in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 AnimeWallpaper
 =====================
 
-Download high quality pictures from [Konachan] (https://Konachan.net).
+Download high quality pictures from [Konachan](https://Konachan.net).
  
 
 ![Blur](blur.gif)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 AnimeWallpaper
 =====================
 
-Download high quality pictures from Konachan.net.
+Download high quality pictures from [Konachan](https://Konachan.net).
 
 
 ![Blur](blur.gif)

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@
 AnimeWallpaper
 =====================
 
-Download high quality pictures from [Konachan](https://Konachan.net).
-
+Download high quality pictures from [Konachan] (https://Konachan.net).
+ 
 
 ![Blur](blur.gif)
 


### PR DESCRIPTION
I saw the reference to "Konachan.net" in README which was not a proper visitable link, I think it should rather be a clickable link which will take us to [Konachan](https://Konachan.net) so I've done the required updates in README.

I hope this looks good.